### PR TITLE
Make Type.Compare.Plugin use matching rather than splitTyConApp_maybe

### DIFF
--- a/cmptype/src/Type/Compare/Plugin.hs
+++ b/cmptype/src/Type/Compare/Plugin.hs
@@ -1,25 +1,24 @@
-{-# LANGUAGE BangPatterns  #-}
-{-# LANGUAGE LambdaCase    #-}
-{-# LANGUAGE TupleSections #-}
-{-# OPTIONS_GHC -Wall      #-}
+{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -Wall   #-}
 
 module Type.Compare.Plugin (plugin) where
 
-import Plugin.MagicTyFam (magicTyFamPlugin, isTyFamFree)
-import Control.Applicative (liftA2)
 import Control.Monad (guard)
-import Data.List (intercalate)
+import Data.Maybe (fromMaybe)
+import FastString (unpackFS)
 import GHC.NameViolation (violateName, showName)
-import GhcPlugins
-
+import GhcPlugins hiding ((<>))
+import Plugin.MagicTyFam (magicTyFamPlugin, isTyFamFree)
+import TyCoRep
 
 ------------------------------------------------------------------------------
 -- | This plugin automagically solves 'Type.Compare.CmpType'. Enable the GHC
 -- flag @-fplugin=Type.Compare.Plugin@ in order to use it.
 plugin :: Plugin
-plugin = magicTyFamPlugin "cmptype" "Type.Compare" "CmpTypeImpl" $ \[_, a, b] ->
-  fmap promoteOrdering $ liftA2 compare (hash a) (hash b)
-
+plugin = magicTyFamPlugin "cmptype" "Type.Compare" "CmpTypeImpl" $ \[_, a, b] -> do
+  guard $ isTyFamFree a
+  guard $ isTyFamFree b
+  pure $ promoteOrdering $ compareTypes a b
 
 promoteOrdering :: Ordering -> Type
 promoteOrdering = flip mkTyConApp [] . \case
@@ -27,11 +26,71 @@ promoteOrdering = flip mkTyConApp [] . \case
    EQ -> promotedEQDataCon
    GT -> promotedGTDataCon
 
+-- Note: pprTraceIt function is quite useful for debugging this if it goes awry.
 
-hash :: Type -> Maybe String
-hash t = do
-  guard $ isTyFamFree t
-  (c, as) <- splitTyConApp_maybe t
-  hs <- traverse hash as
-  pure $ intercalate " " $ showName (violateName $ getName c) : hs
+compareTypes :: Type -> Type -> Ordering
+compareTypes lty rty =
+ case (applyTcView lty, applyTcView rty) of
+  (TyVarTy{}, _) -> tyVarError
+  (_, TyVarTy{}) -> tyVarError
 
+  (AppTy f x, AppTy g y) ->
+    compareTypes f g <> compareTypes x y
+
+  (TyConApp lc la, TyConApp rc ra) ->
+    compareTyCons lc rc <> compareArgs la ra
+
+  (ForAllTy{}, _) -> forallError
+  (_, ForAllTy{}) -> forallError
+
+  (FunTy li lo, FunTy ri ro) ->
+    compareTypes li ri <> compareTypes lo ro
+
+  (LitTy l, LitTy r) ->
+    compareTyLits l r
+
+  (CastTy{}, _) -> castError
+  (_, CastTy{}) -> castError
+
+  (CoercionTy{}, _) -> coercionError
+  (_, CoercionTy{}) -> coercionError
+
+  (AppTy{}, _) -> LT
+  (_, AppTy{}) -> GT
+
+  (TyConApp{}, _) -> LT
+  (_, TyConApp{}) -> GT
+
+  (FunTy{}, _) -> LT
+  (_, FunTy{}) -> GT
+
+compareTyCons :: TyCon -> TyCon -> Ordering
+compareTyCons l r = compare (tyConToString l) (tyConToString r)
+
+tyConToString :: TyCon -> String
+tyConToString = showName . violateName . getName
+
+compareArgs :: [Type] -> [Type] -> Ordering
+compareArgs [] [] = EQ
+compareArgs [] _ = GT
+compareArgs _ [] = LT
+compareArgs (l : ls) (r : rs) =
+  compareTypes l r <> compareArgs ls rs
+
+compareTyLits :: TyLit -> TyLit -> Ordering
+compareTyLits (NumTyLit l) (NumTyLit r) = compare l r
+compareTyLits (StrTyLit l) (StrTyLit r) = compare (unpackFS l) (unpackFS r)
+
+compareTyLits NumTyLit{} _ = LT
+compareTyLits _ NumTyLit{} = GT
+
+applyTcView :: Type -> Type
+applyTcView ty = fromMaybe ty $ tcView ty
+
+forallError, tyVarError, castError, coercionError :: a
+forallError = error "CmpType does not currently support impredicative types"
+
+-- TODO: Can any of these happen in practice?
+tyVarError = error "Unexpected: CmpType encountered ty var"
+castError = error "Unexpected: CmpType encountered kind cast"
+coercionError = error "Unexpected: CmpType encountered coercion"

--- a/cmptype/test/ShouldTypecheck.hs
+++ b/cmptype/test/ShouldTypecheck.hs
@@ -118,3 +118,5 @@ testType22 :: Proxy (CmpType '(String, Bool, '(Int, "b", String), Int)
                              '(String, Bool, '(Int, "b", String), Int)) -> Proxy 'EQ
 testType22 = id
 
+testType23 :: Proxy (CmpType (Proxy "banana") (Proxy Int)) -> Proxy 'GT
+testType23 = id


### PR DESCRIPTION
This fixes #9.  I also think this is an improvement in general:

* Makes it clear the cases that aren't handled

* If GHC's `Type` changes, we'll get errors / warnings

* Probably faster

* The string building version didn't have any indication of nesting.  I didn't find a concrete case where this is a problem, but it seemed iffy