### PR TITLE
Polykinded cmptype

### DIFF
--- a/cmptype/src/Type/Compare.hs
+++ b/cmptype/src/Type/Compare.hs
@@ -6,6 +6,7 @@
 
 module Type.Compare
   ( CmpType
+  , PolyKindedCmpType
   ) where
 
 import GHC.TypeLits
@@ -21,10 +22,14 @@ import Data.List
 --
 -- The actual /meaning/ of comparing types is left to your imagination. But it's
 -- deterministic so that's good enough.
-type family CmpType (a :: k) (b :: k) :: Ordering where
+type CmpType (a :: k) (b :: k) = PolyKindedCmpType a b
+
+-- | Like 'CmpType', but does not enforce that the types are of the
+-- same kind.
+type family PolyKindedCmpType (a :: ka) (b :: kb) :: Ordering where
   CmpType a             a = 'EQ
-  CmpType (a :: Nat)    b = CmpNat a b
-  CmpType (a :: Symbol) b = CmpSymbol a b
+  CmpType (a :: Nat)    (b :: Nat) = CmpNat a b
+  CmpType (a :: Symbol) (b :: Symbol) = CmpSymbol a b
 
   -- These instances are generated via '_generateCmpType'
   CmpType '(a1, a2) '(b1, b2) = OrderingSemigroup (CmpType a1 b1) (OrderingSemigroup (CmpType a2 b2) ('EQ))
@@ -99,7 +104,7 @@ type family OrderingSemigroup (a :: Ordering) (b :: Ordering) :: Ordering where
   OrderingSemigroup 'EQ b = b
   OrderingSemigroup a _   = a
 
-type family CmpTypeImpl (a :: k) (b :: k) :: Ordering where
+type family CmpTypeImpl (a :: ka) (b :: kb) :: Ordering where
 
 
 

--- a/cmptype/src/Type/Compare/Plugin.hs
+++ b/cmptype/src/Type/Compare/Plugin.hs
@@ -1,25 +1,24 @@
-{-# LANGUAGE BangPatterns  #-}
-{-# LANGUAGE LambdaCase    #-}
-{-# LANGUAGE TupleSections #-}
-{-# OPTIONS_GHC -Wall      #-}
+{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -Wall   #-}
 
 module Type.Compare.Plugin (plugin) where
 
-import Plugin.MagicTyFam (magicTyFamPlugin, isTyFamFree)
-import Control.Applicative (liftA2)
 import Control.Monad (guard)
-import Data.List (intercalate)
+import Data.Maybe (fromMaybe)
+import FastString (unpackFS)
 import GHC.NameViolation (violateName, showName)
-import GhcPlugins
-
+import GhcPlugins hiding ((<>))
+import Plugin.MagicTyFam (magicTyFamPlugin, isTyFamFree)
+import TyCoRep
 
 ------------------------------------------------------------------------------
 -- | This plugin automagically solves 'Type.Compare.CmpType'. Enable the GHC
 -- flag @-fplugin=Type.Compare.Plugin@ in order to use it.
 plugin :: Plugin
-plugin = magicTyFamPlugin "cmptype" "Type.Compare" "CmpTypeImpl" $ \[_, a, b] ->
-  fmap promoteOrdering $ liftA2 compare (hash a) (hash b)
-
+plugin = magicTyFamPlugin "cmptype" "Type.Compare" "CmpTypeImpl" $ \[_, a, b] -> do
+  guard $ isTyFamFree a
+  guard $ isTyFamFree b
+  pure $ promoteOrdering $ compareTypes a b
 
 promoteOrdering :: Ordering -> Type
 promoteOrdering = flip mkTyConApp [] . \case
@@ -27,11 +26,71 @@ promoteOrdering = flip mkTyConApp [] . \case
    EQ -> promotedEQDataCon
    GT -> promotedGTDataCon
 
+-- Note: pprTraceIt function is quite useful for debugging this if it goes awry.
 
-hash :: Type -> Maybe String
-hash t = do
-  guard $ isTyFamFree t
-  (c, as) <- splitTyConApp_maybe t
-  hs <- traverse hash as
-  pure $ intercalate " " $ showName (violateName $ getName c) : hs
+compareTypes :: Type -> Type -> Ordering
+compareTypes lty rty =
+ case (applyTcView lty, applyTcView rty) of
+  (TyVarTy{}, _) -> tyVarError
+  (_, TyVarTy{}) -> tyVarError
 
+  (AppTy f x, AppTy g y) ->
+    compareTypes f g <> compareTypes x y
+
+  (TyConApp lc la, TyConApp rc ra) ->
+    compareTyCons lc rc <> compareArgs la ra
+
+  (ForAllTy{}, _) -> forallError
+  (_, ForAllTy{}) -> forallError
+
+  (FunTy li lo, FunTy ri ro) ->
+    compareTypes li ri <> compareTypes lo ro
+
+  (LitTy l, LitTy r) ->
+    compareTyLits l r
+
+  (CastTy{}, _) -> castError
+  (_, CastTy{}) -> castError
+
+  (CoercionTy{}, _) -> coercionError
+  (_, CoercionTy{}) -> coercionError
+
+  (AppTy{}, _) -> LT
+  (_, AppTy{}) -> GT
+
+  (TyConApp{}, _) -> LT
+  (_, TyConApp{}) -> GT
+
+  (FunTy{}, _) -> LT
+  (_, FunTy{}) -> GT
+
+compareTyCons :: TyCon -> TyCon -> Ordering
+compareTyCons l r = compare (tyConToString l) (tyConToString r)
+
+tyConToString :: TyCon -> String
+tyConToString = showName . violateName . getName
+
+compareArgs :: [Type] -> [Type] -> Ordering
+compareArgs [] [] = EQ
+compareArgs [] _ = GT
+compareArgs _ [] = LT
+compareArgs (l : ls) (r : rs) =
+  compareTypes l r <> compareArgs ls rs
+
+compareTyLits :: TyLit -> TyLit -> Ordering
+compareTyLits (NumTyLit l) (NumTyLit r) = compare l r
+compareTyLits (StrTyLit l) (StrTyLit r) = compare (unpackFS l) (unpackFS r)
+
+compareTyLits NumTyLit{} _ = LT
+compareTyLits _ NumTyLit{} = GT
+
+applyTcView :: Type -> Type
+applyTcView ty = fromMaybe ty $ tcView ty
+
+forallError, tyVarError, castError, coercionError :: a
+forallError = error "CmpType does not currently support impredicative types"
+
+-- TODO: Can any of these happen in practice?
+tyVarError = error "Unexpected: CmpType encountered ty var"
+castError = error "Unexpected: CmpType encountered kind cast"
+coercionError = error "Unexpected: CmpType encountered coercion"

--- a/cmptype/src/Type/Compare/Plugin.hs
+++ b/cmptype/src/Type/Compare/Plugin.hs
@@ -15,7 +15,7 @@ import TyCoRep
 -- | This plugin automagically solves 'Type.Compare.CmpType'. Enable the GHC
 -- flag @-fplugin=Type.Compare.Plugin@ in order to use it.
 plugin :: Plugin
-plugin = magicTyFamPlugin "cmptype" "Type.Compare" "CmpTypeImpl" $ \[_, a, b] -> do
+plugin = magicTyFamPlugin "cmptype" "Type.Compare" "CmpTypeImpl" $ \[_, _, a, b] -> do
   guard $ isTyFamFree a
   guard $ isTyFamFree b
   pure $ promoteOrdering $ compareTypes a b

--- a/cmptype/test/ShouldTypecheck.hs
+++ b/cmptype/test/ShouldTypecheck.hs
@@ -118,3 +118,5 @@ testType22 :: Proxy (CmpType '(String, Bool, '(Int, "b", String), Int)
                              '(String, Bool, '(Int, "b", String), Int)) -> Proxy 'EQ
 testType22 = id
 
+testType23 :: Proxy (CmpType (Proxy "banana") (Proxy Int)) -> Proxy 'GT
+testType23 = id

--- a/cmptype/test/ShouldTypecheck.hs
+++ b/cmptype/test/ShouldTypecheck.hs
@@ -120,3 +120,6 @@ testType22 = id
 
 testType23 :: Proxy (CmpType (Proxy "banana") (Proxy Int)) -> Proxy 'GT
 testType23 = id
+
+testType24 :: Proxy (PolyKindedCmpType "banana" Int) -> Proxy 'GT
+testType24 = id


### PR DESCRIPTION
This PR includes the commits from PR #10, and adds support for comparison of types which have different kinds, as mentioned in #9 

It is consistent to support this, since polykinded comparison can already be done via `CmpType (Proxy x) (Proxy y)` where `x` and `y` have different kinds.

Could also just make `CmpType` allow the kinds to vary.  However I think it is probably better to encourage comparison of types of the same kind, and so I kept the existing kind for `CmpType` and made it a type synonym.